### PR TITLE
Fix reference to executable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 Modify _my-lambda/package.json_:
 ```
 "scripts": {
-    "build-aws-lambda": "repack-zip-alt"
+    "build-aws-lambda": "repack-zip"
     ...
 }
 ```


### PR DESCRIPTION
Your `package.json` specifies the executable name `repack-zip`, not `repack-zip-alt` (see [here](https://github.com/Enalmada/node-repack-zip/blob/b829cc514b23f7f2ce7be5e9bf451f533500b9aa/package.json#L15)). I've renamed the reference in `README.md`. Alternatively you could update the name in `package.json`.